### PR TITLE
fix(autoUpdate): 将 registerAutoUpdateEvents 移至 app.whenReady 之前以避免时序问题

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -464,6 +464,9 @@ function createWindow(): void {
 
 import { registerAutoUpdateEvents, initAutoUpdateForWindow } from './events/autoUpdate'
 
+// 注册自动更新事件 - 尽早注册以避免时序问题
+registerAutoUpdateEvents()
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -546,8 +549,6 @@ app.whenReady().then(async () => {
     console.log('Auth server listening on http://127.0.0.1:43110')
   })
 
-  // 注册自动更新事件
-  registerAutoUpdateEvents()
   ipcMain.on('startPing', () => {
     if (ping) clearInterval(ping)
     console.log('start-----开始')


### PR DESCRIPTION
将自动更新事件的注册提前到 app.whenReady() 之前执行，确保在应用初始化早期就能正确注册所有 IPC 监听器，避免潜在的时序问题。

同时删除了 whenReady() 回调中的重复调用。