### PR TITLE
fix: 修复下载界面音质选择弹窗在黑夜模式下的背景色问题 (#65)

### DIFF
--- a/src/renderer/src/utils/audio/download.ts
+++ b/src/renderer/src/utils/audio/download.ts
@@ -77,19 +77,19 @@ export function createQualityDialog(
                     class: 'quality-item',
                     title: undefined,
                     style: {
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      padding: '12px 16px',
-                      margin: '8px 0',
-                      border: '1px solid ' + (disabled ? '#f0f0f0' : '#e7e7e7'),
-                      borderRadius: '6px',
-                      cursor: disabled ? 'not-allowed' : 'pointer',
-                      transition: 'all 0.2s ease',
-                      backgroundColor:
-                        quality.type === userQuality ? (disabled ? '#f5faff' : '#e6f7ff') : '#fff',
-                      opacity: disabled ? 0.55 : 1
-                    },
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '12px 16px',
+                  margin: '8px 0',
+                  border: '1px solid ' + (disabled ? 'var(--td-border-level-2-color)' : 'var(--td-border-level-1-color)'),
+                  borderRadius: '6px',
+                  cursor: disabled ? 'not-allowed' : 'pointer',
+                  transition: 'all 0.2s ease',
+                  backgroundColor:
+                    quality.type === userQuality ? 'var(--td-brand-color-light)' : 'var(--td-bg-color-container)',
+                  opacity: disabled ? 0.55 : 1
+                },
                     onClick: () => {
                       if (disabled) return
                       dialog.destroy()
@@ -98,14 +98,14 @@ export function createQualityDialog(
                     onMouseenter: (e: MouseEvent) => {
                       if (disabled) return
                       const target = e.target as HTMLElement
-                      target.style.backgroundColor = '#f0f9ff'
-                      target.style.borderColor = '#1890ff'
+                      target.style.backgroundColor = 'var(--td-bg-color-secondarycontainer)'
+                      target.style.borderColor = 'var(--td-brand-color)'
                     },
                     onMouseleave: (e: MouseEvent) => {
                       const target = e.target as HTMLElement
                       target.style.backgroundColor =
-                        quality.type === userQuality ? '#e6f7ff' : '#fff'
-                      target.style.borderColor = '#e7e7e7'
+                        quality.type === userQuality ? 'var(--td-brand-color-light)' : 'var(--td-bg-color-container)'
+                      target.style.borderColor = 'var(--td-border-level-1-color)'
                     }
                   },
                   [
@@ -116,7 +116,7 @@ export function createQualityDialog(
                           style: {
                             fontWeight: '500',
                             fontSize: '14px',
-                            color: quality.type === userQuality ? '#1890ff' : '#333'
+                            color: quality.type === userQuality ? 'var(--td-brand-color)' : 'var(--td-text-color-primary)'
                           }
                         },
                         getQualityDisplayName(quality.type)
@@ -126,7 +126,7 @@ export function createQualityDialog(
                         {
                           style: {
                             fontSize: '12px',
-                            color: '#999',
+                            color: 'var(--td-text-color-secondary)',
                             marginTop: '2px'
                           }
                         },
@@ -139,7 +139,7 @@ export function createQualityDialog(
                         class: 'quality-size',
                         style: {
                           fontSize: '12px',
-                          color: '#666',
+                          color: 'var(--td-text-color-secondary)',
                           fontWeight: '500'
                         }
                       },


### PR DESCRIPTION
## 问题描述
修复 #65 - 下载界面音质选择弹窗在黑夜模式下的背景色问题

## 修复内容
将 `createQualityDialog` 函数中的硬编码颜色值替换为 TDesign CSS 变量：

| 原硬编码颜色 | 替换为 CSS 变量 |
|-------------|----------------|
| `#fff` (背景) | `var(--td-bg-color-container)` |
| `#e6f7ff` (选中背景) | `var(--td-brand-color-light)` |
| `#f0f9ff` (hover背景) | `var(--td-bg-color-secondarycontainer)` |
| `#e7e7e7` (边框) | `var(--td-border-level-1-color)` |
| `#1890ff` (主题色) | `var(--td-brand-color)` |
| `#333` (主文字) | `var(--td-text-color-primary)` |
| `#666`, `#999` (次要文字) | `var(--td-text-color-secondary)` |

## 效果
- 白天模式：保持原有浅色主题
- 黑夜模式：自动切换为深色背景

## 测试
- TypeScript 检查已通过
- 应用可正常启动运行