### PR TITLE
feat: 全局均衡器预设管理功能增强 - 支持删除、保存和智能重置

### DIFF
--- a/src/renderer/src/store/Equalizer.ts
+++ b/src/renderer/src/store/Equalizer.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue'
 export interface EqualizerPreset {
   name: string
   gains: number[]
+  basePreset?: string // 记录基于哪个预设创建的，用于重置时恢复
 }
 
 export const useEqualizerStore = defineStore(


### PR DESCRIPTION
## 功能描述
为全局均衡器（Professional EQ）添加完整的预设管理功能。

## 新增功能

### 1. 删除自定义预设
- 在预设选择器旁添加"删除"按钮（仅对自定义预设显示）
- 内置预设（Flat, Pop, Rock, Jazz, Classical, Bass Boost, Vocal Boost, Treble Boost）受保护，不可删除
- 删除后自动切换到 Flat 预设

### 2. 保存当前值到预设
- 在预设选择器旁添加"保存当前值"按钮（仅对自定义预设显示）
- 允许将当前调整的增益值保存到现有自定义预设
- 无需删除再创建，直接更新预设值

### 3. 智能重置逻辑
- **内置预设**：重置时恢复到该预设的原始值
- **自定义预设**：重置时恢复到**创建时基于的源预设值**
  - 新增 `basePreset` 字段记录源预设
  - 例如：从 Jazz 创建的预设，重置时回到 Jazz 的值
  - 从 Rock 创建的预设，重置时回到 Rock 的值
  - 兼容旧数据：无 `basePreset` 的预设重置到 Flat
 
### 预览
<img width="890" height="626" alt="PixPin_2026-02-24_22-21-46" src="https://github.com/user-attachments/assets/91c97d01-da90-452c-83c7-a6903825d3e8" />
