### PR TITLE
fix: 优化切歌时SMTC更新时序，解决切换时空隙导致不显示的问题

### DIFF
--- a/src/renderer/src/utils/audio/globaPlayList.ts
+++ b/src/renderer/src/utils/audio/globaPlayList.ts
@@ -165,12 +165,7 @@ const playSong = async (song: SongList) => {
     songInfo.value.albumName = song.albumName
     songInfo.value.img = song.img
     userInfo.value.lastPlaySongId = song.songmid
-    mediaSessionController.updateMetadata({
-      title: song.name,
-      artist: song.singer,
-      album: song.albumName || '未知专辑',
-      artworkUrl: song.img || defaultCoverImg
-    })
+    // 注意：SMTC 的 updateMetadata 会在音频准备好后再调用，避免切换时空隙
 
     let urlToPlay = ''
     // let usedAutoSwitch = false
@@ -224,7 +219,13 @@ const playSong = async (song: SongList) => {
                 MessagePlugin.success(`已自动切换到 ${item.source} 源播放`)
                 playSuccess = true
                 urlToPlay = url
-                songInfo.value = { ...song }
+                // 音频已就绪后再更新 SMTC，避免切换时空隙
+                mediaSessionController.updateMetadata({
+                  title: song.name,
+                  artist: song.singer,
+                  album: song.albumName || '未知专辑',
+                  artworkUrl: song.img || defaultCoverImg
+                })
                 break
               } catch (e) {
                 continue
@@ -293,6 +294,13 @@ const playSong = async (song: SongList) => {
 
                   MessagePlugin.success(`已自动切换到 ${item.source} 源播放`)
                   playSuccess = true
+                  // 音频已就绪后再更新 SMTC，避免切换时空隙
+                  mediaSessionController.updateMetadata({
+                    title: song.name,
+                    artist: song.singer,
+                    album: song.albumName || '未知专辑',
+                    artworkUrl: song.img || defaultCoverImg
+                  })
                   break
                 } catch (e) {
                   continue
@@ -317,7 +325,13 @@ const playSong = async (song: SongList) => {
 
     if (currentPlayRequestId !== requestId) return
 
-    songInfo.value = { ...song }
+    // 音频已就绪后再更新 SMTC，避免切换时空隙
+    mediaSessionController.updateMetadata({
+      title: song.name,
+      artist: song.singer,
+      album: song.albumName || '未知专辑',
+      artworkUrl: song.img || defaultCoverImg
+    })
     isLoadingSong.value = false
     start()
       .catch(async () => {
@@ -574,18 +588,20 @@ const initPlayback = async () => {
   if (userInfo.value.lastPlaySongId && list.value.length > 0) {
     const lastPlayedSong = list.value.find((song) => song.songmid === userInfo.value.lastPlaySongId)
     if (lastPlayedSong) {
+      // UI 立即更新
       songInfo.value = { ...lastPlayedSong }
-      mediaSessionController.updateMetadata({
-        title: lastPlayedSong.name,
-        artist: lastPlayedSong.singer,
-        album: lastPlayedSong.albumName || '未知专辑',
-        artworkUrl: lastPlayedSong.img || defaultCoverImg
-      })
       if (!Audio.value.isPlay) {
         try {
           console.log('initPlayback', lastPlayedSong)
           const url = await getSongRealUrl(toRaw(lastPlayedSong))
           setUrl(url)
+          // SMTC 元数据在音频准备好后再更新，避免切换时空隙
+          mediaSessionController.updateMetadata({
+            title: lastPlayedSong.name,
+            artist: lastPlayedSong.singer,
+            album: lastPlayedSong.albumName || '未知专辑',
+            artworkUrl: lastPlayedSong.img || defaultCoverImg
+          })
         } catch {}
         if (userInfo.value.currentTime) {
           pendingRestorePosition = userInfo.value.currentTime
@@ -598,6 +614,13 @@ const initPlayback = async () => {
           }
         }
       } else {
+        // 如果已经在播放，更新 SMTC
+        mediaSessionController.updateMetadata({
+          title: lastPlayedSong.name,
+          artist: lastPlayedSong.singer,
+          album: lastPlayedSong.albumName || '未知专辑',
+          artworkUrl: lastPlayedSong.img || defaultCoverImg
+        })
         if (Audio.value.audio) {
           mediaSessionController.updatePlaybackState(
             Audio.value.audio.paused ? 'paused' : 'playing'


### PR DESCRIPTION
## 问题描述
在上一个PR中，我尝试解决在切歌时SMTC不显示的问题，将 UI 更新移至音频加载完成后这修改方案确实不太妥。
所以这次方案是将 SMTC 的更新时机延迟到音频真正准备好之后来解决SMTC不显示的问题。如果你使用Lyricify Lite的话能很明显的看到SMTC显示问题：

### 当前情况
切歌时会把本来应该显示的SMTC给切没，在切的那一瞬间SMTC是加载出来了的，但是后续却消失了。

![6ajX1QKZ_converted](https://github.com/user-attachments/assets/f8c7fab3-62d5-4b03-bd59-099ce189f80f)

Windows也不显示

<img width="773" height="469" alt="PixPin_2026-03-23_13-44-54" src="https://github.com/user-attachments/assets/a275a2dd-d36b-4f41-93fd-c144497a6ac6" />

### 本次修改后
可以正常加载SMTC
![geu7xag1_converted](https://github.com/user-attachments/assets/458a4027-3c55-4763-82cd-392c57b64bb4)
<img width="689" height="521" alt="PixPin_2026-03-23_13-50-04" src="https://github.com/user-attachments/assets/c02671e1-3ac0-47c5-90dc-9bec03bae291" />


## 解决方案
将 SMTC 的更新时机延迟到音频真正准备好之后：

- **UI 立即更新**：`songInfo` 在切歌瞬间更新，给用户即时响应
- **SMTC 延迟更新**：`mediaSessionController.updateMetadata` 等到音频就绪后再调用

这样设计既保证了用户体验，又解决了 SMTC 问题。

## 修改内容
- `src/renderer/src/utils/audio/globaPlayList.ts`
  - `playSong()` 函数：UI 立即响应，SMTC 在音频就绪后更新
  - `initPlayback()` 函数：同样优化时序